### PR TITLE
fixed RCC under QT5+ (which uses different qHash implementation)

### DIFF
--- a/tools/rcc/rcc.cpp
+++ b/tools/rcc/rcc.cpp
@@ -302,7 +302,11 @@ qint64 RCCFileInfo::writeDataName(RCCResourceLibrary &lib, qint64 offset)
     offset += 2;
 
     // write the hash
+#if QT_VERSION >= 0x050000
+    lib.writeNumber4(qt_hash(m_name));
+#else
     lib.writeNumber4(qHash(m_name));
+#endif
     if (text)
         lib.writeString("\n  ");
     offset += 4;


### PR DESCRIPTION
fix for https://github.com/visualfc/goqt/issues/9