### PR TITLE
Added call to runtime.LockOSThread() to ensure that QApplication is c…

### DIFF
--- a/ui/app.go
+++ b/ui/app.go
@@ -6,6 +6,7 @@ package ui
 
 import (
 	"log"
+	"runtime"
 )
 
 func Version() string {
@@ -18,6 +19,7 @@ func Async(fn func()) {
 }
 
 func Run(fn func()) int32 {
+	runtime.LockOSThread()
 	if qtdrv_init_error != nil {
 		log.Println(qtdrv_init_error)
 		return -2
@@ -30,6 +32,7 @@ func Run(fn func()) int32 {
 }
 
 func RunEx(args []string, fn func()) int32 {
+	runtime.LockOSThread()
 	if qtdrv_init_error != nil {
 		log.Println(qtdrv_init_error)
 		return -2


### PR DESCRIPTION
…reated in the main thread

Sometimes I get following warning:
WARNING: QApplication was not created in the main() thread.
And application refuses to display anything. Got this just few times under OS X plus getting it quite frequently (probably around 5% of executions) under Raspbian in RPi 2.

Patch should fix that behavior (bug itself is random and I wasn't able to reproduce it after applying patch)