### PR TITLE
Added call to runtime.LockOSThread() to ensure that QApplication is created in the OS main thread

### DIFF
--- a/ui/app.go
+++ b/ui/app.go
@@ -6,6 +6,7 @@ package ui
 
 import (
 	"log"
+	"runtime"
 )
 
 func Version() string {
@@ -18,6 +19,7 @@ func Async(fn func()) {
 }
 
 func Run(fn func()) int32 {
+	runtime.LockOSThread()
 	if qtdrv_init_error != nil {
 		log.Println(qtdrv_init_error)
 		return -2
@@ -30,6 +32,7 @@ func Run(fn func()) int32 {
 }
 
 func RunEx(args []string, fn func()) int32 {
+	runtime.LockOSThread()
 	if qtdrv_init_error != nil {
 		log.Println(qtdrv_init_error)
 		return -2


### PR DESCRIPTION
Fixes https://github.com/visualfc/goqt/issues/22

Patch should fix that behavior (bug itself is random but I wasn't able to reproduce it after applying patch and it was easy to reproduce before)

See https://github.com/golang/go/wiki/LockOSThread for more details